### PR TITLE
sbfv2: static syscalls, clang cpu flag

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -146,6 +146,8 @@ mod c {
         let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
         let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
         let target_vendor = env::var("CARGO_CFG_TARGET_VENDOR").unwrap();
+        let target_feature = env::var("CARGO_CFG_TARGET_FEATURE").unwrap();
+
         let mut consider_float_intrinsics = true;
         let cfg = &mut cc::Build::new();
 
@@ -503,6 +505,13 @@ mod c {
 
         if target_arch == "bpf" || target_arch == "sbf" {
             cfg.define("__ELF__", None);
+
+            // Use the static-syscall target feature to detect if we're
+            // compiling for sbfv2, in which case set the corresponding clang
+            // cpu flag.
+            if target_arch == "sbf" && target_feature.contains("static-syscalls") {
+                cfg.flag("-mcpu=sbfv2");
+            }
 
             // Add the 128 bit implementations
             sources.extend(&[

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,4 +70,12 @@ pub mod x86;
 #[cfg(target_arch = "x86_64")]
 pub mod x86_64;
 
+#[cfg(all(target_arch = "sbf", target_feature = "static-syscalls"))]
+#[cfg_attr(not(feature = "mangled-names"), no_mangle)]
+#[linkage = "weak"]
+pub unsafe extern "C" fn abort() -> ! {
+    let syscall: extern "C" fn() -> ! = core::mem::transmute(3069975057u64); // murmur32 hash of "abort"
+    syscall()
+}
+
 pub mod probestack;


### PR DESCRIPTION
This includes the changes required to compile sbfv2. It switches to static syscalls, implements abort as a syscall so anything that traps/aborts at the llvm level exits correctly, and passes -mcpu=sbfv2 to clang when required.