### PR TITLE
[SOL] Revert "Update codes for static syscalls (#24)"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
         include:
         - target: aarch64-apple-darwin
           os: macos-14
-          rust: nightly
+          rust: nightly-2024-05-17
         - target: aarch64-unknown-linux-gnu
           os: ubuntu-latest
           rust: nightly-2024-05-17
@@ -27,10 +27,10 @@ jobs:
           rust: nightly-2024-05-17
         - target: i586-unknown-linux-gnu
           os: ubuntu-latest
-          rust: nightly
+          rust: nightly-2024-05-17
         - target: i686-unknown-linux-gnu
           os: ubuntu-latest
-          rust: nightly
+          rust: nightly-2024-05-17
         # MIPS targets disabled since they are dropped to tier 3.
         # See https://github.com/rust-lang/compiler-team/issues/648
         #- target: mips-unknown-linux-gnu
@@ -71,16 +71,16 @@ jobs:
           rust: nightly-2024-05-17
         - target: wasm32-unknown-unknown
           os: ubuntu-latest
-          rust: nightly
+          rust: nightly-2024-05-17
         - target: x86_64-unknown-linux-gnu
           os: ubuntu-latest
-          rust: nightly
+          rust: nightly-2024-05-17
         - target: x86_64-apple-darwin
           os: macos-latest
-          rust: nightly
+          rust: nightly-2024-05-17
         - target: i686-pc-windows-msvc
           os: windows-latest
-          rust: nightly
+          rust: nightly-2024-05-17
         - target: x86_64-pc-windows-msvc
           os: windows-latest
           rust: nightly-2024-05-17
@@ -140,7 +140,7 @@ jobs:
     # This acquires the most recent nightly with a clippy component.
     - name: Install nightly `clippy`
       run: |
-        rustup set profile minimal && rustup default "nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/clippy)" && rustup component add clippy
+        rustup set profile minimal && rustup default nightly-2024-05-17 && rustup component add clippy
     - run: cargo clippy -- -D clippy::all
 
   success:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ pub mod x86_64;
 #[cfg_attr(not(feature = "mangled-names"), no_mangle)]
 #[linkage = "weak"]
 pub unsafe extern "C" fn abort() -> ! {
-    let syscall: extern "C" fn() -> ! = core::mem::transmute(1usize); // 1 is the code for "abort"
+    let syscall: extern "C" fn() -> ! = core::mem::transmute(3069975057u64); // murmur32 hash of "abort"
     syscall()
 }
 

--- a/src/mem/mod.rs
+++ b/src/mem/mod.rs
@@ -219,24 +219,25 @@ mod syscalls {
 mod syscalls {
     pub(crate) fn sol_memcpy_(dest: *mut u8, src: *const u8, n: u64) {
         let syscall: extern "C" fn(*mut u8, *const u8, u64) =
-            unsafe { core::mem::transmute(3usize) }; // 3 is the code for "sol_memcpy_"
+            unsafe { core::mem::transmute(1904002211u64) }; // murmur32 hash of "sol_memcpy_"
         syscall(dest, src, n)
     }
 
     pub(crate) fn sol_memmove_(dest: *mut u8, src: *const u8, n: u64) {
         let syscall: extern "C" fn(*mut u8, *const u8, u64) =
-            unsafe { core::mem::transmute(4usize) }; // 4 is the code for "sol_memmove_"
+            unsafe { core::mem::transmute(1128493560u64) }; // murmur32 hash of "sol_memmove_"
         syscall(dest, src, n)
     }
 
     pub(crate) fn sol_memcmp_(dest: *const u8, src: *const u8, n: u64, result: *mut i32) {
         let syscall: extern "C" fn(*const u8, *const u8, u64, *mut i32) =
-            unsafe { core::mem::transmute(6usize) }; // 6 is the code for "sol_memcmp_"
+            unsafe { core::mem::transmute(1608310321u64) }; // murmur32 hash of "sol_memcmp_"
         syscall(dest, src, n, result)
     }
 
     pub(crate) fn sol_memset_(dest: *mut u8, c: u8, n: u64) {
-        let syscall: extern "C" fn(*mut u8, u8, u64) = unsafe { core::mem::transmute(5usize) }; // 5 is the code for "sol_memset_"
+        let syscall: extern "C" fn(*mut u8, u8, u64) =
+            unsafe { core::mem::transmute(930151202u64) }; // murmur32 hash of "sol_memset_"
         syscall(dest, c, n)
     }
 }


### PR DESCRIPTION
As per the [conversation thread](https://github.com/solana-foundation/solana-improvement-documents/pull/178#discussion_r1927605962) in [SIMD-0178](https://github.com/solana-foundation/solana-improvement-documents/pull/178), we are going to continue using murmur32 hashes for syscall identification.