### PR TITLE
[SOL] Remove abort from compiler-builtins

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,12 +78,4 @@ pub mod x86;
 #[cfg(target_arch = "x86_64")]
 pub mod x86_64;
 
-#[cfg(all(target_os = "solana", target_feature = "static-syscalls"))]
-#[cfg_attr(not(feature = "mangled-names"), no_mangle)]
-#[linkage = "weak"]
-pub unsafe extern "C" fn abort() -> ! {
-    let syscall: extern "C" fn() -> ! = core::mem::transmute(3069975057u64); // murmur32 hash of "abort"
-    syscall()
-}
-
 pub mod probestack;


### PR DESCRIPTION
`abort` is already defined in the target specification in Rustc.