### PR TITLE
0.1.138 upgrade (Rust 1.84.1)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,8 @@ name: CI
 on: [push, pull_request]
 
 env:
-  RUSTDOCFLAGS: -Dwarnings
-  RUSTFLAGS: -Dwarnings
+  # RUSTDOCFLAGS: -Dwarnings
+  # RUSTFLAGS: -Dwarnings
   RUST_LLVM_VERSION: 19.1-2024-09-17
   RUST_COMPILER_RT_ROOT: ./compiler-rt
 
@@ -28,10 +28,10 @@ jobs:
           no_std: 1
         - target: arm-unknown-linux-gnueabi
           os: ubuntu-latest
-          rust: nightly
+          rust: nightly-2024-05-17
         - target: arm-unknown-linux-gnueabihf
           os: ubuntu-latest
-          rust: nightly
+          rust: nightly-2024-05-17
         - target: i586-unknown-linux-gnu
           os: ubuntu-latest
           rust: nightly
@@ -57,10 +57,10 @@ jobs:
         #  rust: nightly
         - target: powerpc-unknown-linux-gnu
           os: ubuntu-latest
-          rust: nightly
+          rust: nightly-2024-05-17
         - target: powerpc64-unknown-linux-gnu
           os: ubuntu-latest
-          rust: nightly
+          rust: nightly-2024-05-17
         - target: powerpc64le-unknown-linux-gnu
           os: ubuntu-latest
           rust: nightly
@@ -72,16 +72,16 @@ jobs:
           rust: nightly
         - target: thumbv6m-none-eabi
           os: ubuntu-latest
-          rust: nightly
+          rust: nightly-2024-05-17
         - target: thumbv7em-none-eabi
           os: ubuntu-latest
-          rust: nightly
+          rust: nightly-2024-05-17
         - target: thumbv7em-none-eabihf
           os: ubuntu-latest
-          rust: nightly
+          rust: nightly-2024-05-17
         - target: thumbv7m-none-eabi
           os: ubuntu-latest
-          rust: nightly
+          rust: nightly-2024-05-17
         - target: wasm32-unknown-unknown
           os: ubuntu-latest
           rust: nightly
@@ -101,10 +101,10 @@ jobs:
           test_verbatim: 1
         - target: i686-pc-windows-gnu
           os: windows-latest
-          rust: nightly-i686-gnu
+          rust: nightly
         - target: x86_64-pc-windows-gnu
           os: windows-latest
-          rust: nightly-x86_64-gnu
+          rust: nightly
     steps:
     - name: Print runner information
       run: uname -a

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,6 +67,9 @@ jobs:
         - target: riscv64gc-unknown-linux-gnu
           os: ubuntu-latest
           rust: nightly
+        - target: sbf-solana-solana
+          os: ubuntu-latest
+          rust: nightly
         - target: thumbv6m-none-eabi
           os: ubuntu-latest
           rust: nightly
@@ -112,6 +115,7 @@ jobs:
       run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
       shell: bash
     - run: rustup target add ${{ matrix.target }}
+      if: matrix.target != 'sbf-solana-solana'
     - run: rustup component add llvm-tools-preview
     - uses: Swatinem/rust-cache@v2
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,30 +17,30 @@ jobs:
         include:
         - target: aarch64-apple-darwin
           os: macos-latest
-          rust: nightly
+          rust: nightly-2024-11-01
         - target: aarch64-unknown-linux-gnu
           os: ubuntu-latest
-          rust: nightly
+          rust: nightly-2024-11-01
         - target: aarch64-pc-windows-msvc
           os: windows-latest
-          rust: nightly
+          rust: nightly-2024-11-01
           test_verbatim: 1
           no_std: 1
         - target: arm-unknown-linux-gnueabi
           os: ubuntu-latest
-          rust: nightly-2024-05-17
+          rust: nightly-2024-11-01
         - target: arm-unknown-linux-gnueabihf
           os: ubuntu-latest
-          rust: nightly-2024-05-17
+          rust: nightly-2024-11-01
         - target: i586-unknown-linux-gnu
           os: ubuntu-latest
-          rust: nightly
+          rust: nightly-2024-11-01
         - target: i686-unknown-linux-gnu
           os: ubuntu-latest
-          rust: nightly
+          rust: nightly-2024-11-01
         - target: loongarch64-unknown-linux-gnu
           os: ubuntu-latest
-          rust: nightly
+          rust: nightly-2024-11-01
         # MIPS targets disabled since they are dropped to tier 3.
         # See https://github.com/rust-lang/compiler-team/issues/648
         #- target: mips-unknown-linux-gnu
@@ -57,54 +57,54 @@ jobs:
         #  rust: nightly
         - target: powerpc-unknown-linux-gnu
           os: ubuntu-latest
-          rust: nightly-2024-05-17
+          rust: nightly-2024-11-01
         - target: powerpc64-unknown-linux-gnu
           os: ubuntu-latest
-          rust: nightly-2024-05-17
+          rust: nightly-2024-11-01
         - target: powerpc64le-unknown-linux-gnu
           os: ubuntu-latest
-          rust: nightly
+          rust: nightly-2024-11-01
         - target: riscv64gc-unknown-linux-gnu
           os: ubuntu-latest
-          rust: nightly
+          rust: nightly-2024-11-01
         - target: sbf-solana-solana
           os: ubuntu-latest
-          rust: nightly
+          rust: nightly-2024-11-01
         - target: thumbv6m-none-eabi
           os: ubuntu-latest
-          rust: nightly-2024-05-17
+          rust: nightly-2024-11-01
         - target: thumbv7em-none-eabi
           os: ubuntu-latest
-          rust: nightly-2024-05-17
+          rust: nightly-2024-11-01
         - target: thumbv7em-none-eabihf
           os: ubuntu-latest
-          rust: nightly-2024-05-17
+          rust: nightly-2024-11-01
         - target: thumbv7m-none-eabi
           os: ubuntu-latest
-          rust: nightly-2024-05-17
+          rust: nightly-2024-11-01
         - target: wasm32-unknown-unknown
           os: ubuntu-latest
-          rust: nightly
+          rust: nightly-2024-11-01
         - target: x86_64-unknown-linux-gnu
           os: ubuntu-latest
-          rust: nightly
+          rust: nightly-2024-11-01
         - target: x86_64-apple-darwin
           os: macos-13
-          rust: nightly
+          rust: nightly-2024-11-01
         - target: i686-pc-windows-msvc
           os: windows-latest
-          rust: nightly
+          rust: nightly-2024-11-01
           test_verbatim: 1
         - target: x86_64-pc-windows-msvc
           os: windows-latest
-          rust: nightly
+          rust: nightly-2024-11-01
           test_verbatim: 1
         - target: i686-pc-windows-gnu
           os: windows-latest
-          rust: nightly
+          rust: nightly-2024-11-01-i686-gnu
         - target: x86_64-pc-windows-gnu
           os: windows-latest
-          rust: nightly
+          rust: nightly-2024-11-01
     steps:
     - name: Print runner information
       run: uname -a
@@ -121,7 +121,7 @@ jobs:
       with:
         key: ${{ matrix.target }}
     - name: Cache Docker layers
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       if: matrix.os == 'ubuntu-latest'
       with:
         path: /tmp/.buildx-cache
@@ -188,7 +188,7 @@ jobs:
     # This acquires the most recent nightly with a clippy component.
     - name: Install nightly `clippy`
       run: |
-        rustup set profile minimal && rustup default "nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/clippy)" && rustup component add clippy
+        rustup set profile minimal && rustup default "nightly-2024-11-01" && rustup component add clippy
     - uses: Swatinem/rust-cache@v2
     - run: cargo clippy -- -D clippy::all
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,3 +83,6 @@ panic = 'abort'
 
 [profile.dev]
 panic = 'abort'
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(target_family, values("solana"))', 'cfg(target_feature, values("static-syscalls"))', 'cfg(target_os, values("solana"))'] }

--- a/build.rs
+++ b/build.rs
@@ -51,6 +51,7 @@ fn main() {
         || target.arch.contains("x86")
         || target.arch.contains("aarch64")
         || target.arch.contains("bpf")
+        || target.arch.contains("sbf")
     {
         println!("cargo:rustc-cfg=feature=\"mem-unaligned\"");
     }
@@ -277,7 +278,10 @@ mod c {
     }
 
     /// Compile intrinsics from the compiler-rt C source code
-    pub fn compile(llvm_target: &[&str], target: &Target) {
+    pub fn compile(llvm_target: &[&str], target: &String) {
+        let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+        let target_feature = env::var("CARGO_CFG_TARGET_FEATURE").unwrap_or_default();
+
         let mut consider_float_intrinsics = true;
         let cfg = &mut cc::Build::new();
 
@@ -582,6 +586,23 @@ mod c {
         // OpenHarmony also uses emulated TLS.
         if target.env == "ohos" {
             sources.extend(&[("__emutls_get_address", "emutls.c")]);
+        }
+
+        if target_os == "solana" {
+            cfg.define("__ELF__", None);
+            // Use the static-syscall target feature to detect if we're
+            // compiling for sbfv2, in which case set the corresponding clang
+            // cpu flag.
+            if target_feature.contains("static-syscalls") {
+                cfg.flag("-mcpu=sbfv2");
+            }
+            // Remove the implementations that fail to build.
+            // This list should shrink to zero
+            sources.remove(&[
+                "__int_util", // Unsupported architecture error
+                "__mulvdi3",  // Unsupported signed division
+                "__mulvsi3",  // Unsupported signed division
+            ]);
         }
 
         // When compiling the C code we require the user to tell us where the

--- a/build.rs
+++ b/build.rs
@@ -590,12 +590,6 @@ mod c {
 
         if target_os == "solana" {
             cfg.define("__ELF__", None);
-            // Use the static-syscall target feature to detect if we're
-            // compiling for sbfv2, in which case set the corresponding clang
-            // cpu flag.
-            if target_feature.contains("static-syscalls") {
-                cfg.flag("-mcpu=sbfv2");
-            }
             // Remove the implementations that fail to build.
             // This list should shrink to zero
             sources.remove(&[

--- a/build.rs
+++ b/build.rs
@@ -278,10 +278,7 @@ mod c {
     }
 
     /// Compile intrinsics from the compiler-rt C source code
-    pub fn compile(llvm_target: &[&str], target: &String) {
-        let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
-        let target_feature = env::var("CARGO_CFG_TARGET_FEATURE").unwrap_or_default();
-
+    pub fn compile(llvm_target: &[&str], target: &Target) {
         let mut consider_float_intrinsics = true;
         let cfg = &mut cc::Build::new();
 
@@ -588,7 +585,7 @@ mod c {
             sources.extend(&[("__emutls_get_address", "emutls.c")]);
         }
 
-        if target_os == "solana" {
+        if target.os == "solana" {
             cfg.define("__ELF__", None);
             // Remove the implementations that fail to build.
             // This list should shrink to zero

--- a/ci/docker/sbf-solana-solana/Dockerfile
+++ b/ci/docker/sbf-solana-solana/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:20.04
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    curl \
+    gcc libc6-dev ca-certificates
+
+ENV RUSTUP_INIT_SKIP_PATH_CHECK="yes"
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y -v --no-modify-path
+RUN cp ${HOME}/.cargo/bin/* /usr/local/bin/
+
+RUN cargo install --git https://github.com/solana-labs/cargo-run-solana-tests.git \
+    --rev df2f642924aee7bbd2566017b3d71cb0c389b015 \
+    --bin cargo-run-solana-tests --root /usr/local
+
+RUN mkdir -p /tmp/.cache/solana/v1.38/platform-tools
+RUN curl -L -o platform-tools-linux-x86_64.tar.bz2 https://github.com/solana-labs/platform-tools/releases/download/v1.38/platform-tools-linux-x86_64.tar.bz2
+RUN tar -xjf platform-tools-linux-x86_64.tar.bz2 --strip-components 1 -C /tmp/.cache/solana/v1.38/platform-tools
+RUN rustup toolchain link solana /tmp/.cache/solana/v1.38/platform-tools/rust
+RUN cp -R ${HOME}/.rustup /tmp/
+
+ENV CARGO_TARGET_SBF_SOLANA_SOLANA_RUNNER="cargo-run-solana-tests --heap-size 104857600"
+ENV CC="/tmp/.cache/solana/v1.38/platform-tools/llvm/bin/clang"
+ENV RUSTUP_TOOLCHAIN="solana"

--- a/ci/docker/sbf-solana-solana/Dockerfile
+++ b/ci/docker/sbf-solana-solana/Dockerfile
@@ -2,7 +2,8 @@ FROM ubuntu:22.04
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     curl \
-    gcc libc6-dev ca-certificates bzip2
+    gcc libc6-dev ca-certificates bzip2 \
+    libssl-dev pkg-config
 
 ENV RUSTUP_INIT_SKIP_PATH_CHECK="yes"
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y -v --no-modify-path
@@ -13,7 +14,7 @@ RUN cargo install --git https://github.com/anza-xyz/cargo-run-solana-tests.git \
     --bin cargo-run-solana-tests --root /usr/local
 
 RUN mkdir -p /tmp/.cache/solana/v1.44/platform-tools
-RUN curl -L -o platform-tools-linux-x86_64.tar.bz2 https://github.com/solana-labs/platform-tools/releases/download/v1.44/platform-tools-linux-x86_64.tar.bz2
+RUN curl -L -o platform-tools-linux-x86_64.tar.bz2 https://github.com/anza-xyz/platform-tools/releases/download/v1.44/platform-tools-linux-x86_64.tar.bz2
 RUN tar -xjf platform-tools-linux-x86_64.tar.bz2 --strip-components 1 -C /tmp/.cache/solana/v1.44/platform-tools
 RUN rustup toolchain link solana /tmp/.cache/solana/v1.44/platform-tools/rust
 RUN cp -R ${HOME}/.rustup /tmp/

--- a/ci/docker/sbf-solana-solana/Dockerfile
+++ b/ci/docker/sbf-solana-solana/Dockerfile
@@ -1,23 +1,23 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     curl \
-    gcc libc6-dev ca-certificates
+    gcc libc6-dev ca-certificates bzip2
 
 ENV RUSTUP_INIT_SKIP_PATH_CHECK="yes"
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y -v --no-modify-path
 RUN cp ${HOME}/.cargo/bin/* /usr/local/bin/
 
-RUN cargo install --git https://github.com/solana-labs/cargo-run-solana-tests.git \
-    --rev df2f642924aee7bbd2566017b3d71cb0c389b015 \
+RUN cargo install --git https://github.com/anza-xyz/cargo-run-solana-tests.git \
+    --rev c5df324a62a5e03d2ff5f9efbdbf5a4e4182325e \
     --bin cargo-run-solana-tests --root /usr/local
 
-RUN mkdir -p /tmp/.cache/solana/v1.38/platform-tools
-RUN curl -L -o platform-tools-linux-x86_64.tar.bz2 https://github.com/solana-labs/platform-tools/releases/download/v1.38/platform-tools-linux-x86_64.tar.bz2
-RUN tar -xjf platform-tools-linux-x86_64.tar.bz2 --strip-components 1 -C /tmp/.cache/solana/v1.38/platform-tools
-RUN rustup toolchain link solana /tmp/.cache/solana/v1.38/platform-tools/rust
+RUN mkdir -p /tmp/.cache/solana/v1.44/platform-tools
+RUN curl -L -o platform-tools-linux-x86_64.tar.bz2 https://github.com/solana-labs/platform-tools/releases/download/v1.44/platform-tools-linux-x86_64.tar.bz2
+RUN tar -xjf platform-tools-linux-x86_64.tar.bz2 --strip-components 1 -C /tmp/.cache/solana/v1.44/platform-tools
+RUN rustup toolchain link solana /tmp/.cache/solana/v1.44/platform-tools/rust
 RUN cp -R ${HOME}/.rustup /tmp/
 
 ENV CARGO_TARGET_SBF_SOLANA_SOLANA_RUNNER="cargo-run-solana-tests --heap-size 104857600"
-ENV CC="/tmp/.cache/solana/v1.38/platform-tools/llvm/bin/clang"
+ENV CC="/tmp/.cache/solana/v1.44/platform-tools/llvm/bin/clang"
 ENV RUSTUP_TOOLCHAIN="solana"

--- a/examples/intrinsics.rs
+++ b/examples/intrinsics.rs
@@ -16,7 +16,12 @@
 
 extern crate panic_handler;
 
-#[cfg(all(not(thumb), not(windows), not(target_arch = "wasm32")))]
+#[cfg(all(
+    not(thumb),
+    not(windows),
+    not(target_arch = "wasm32"),
+    not(target_os = "solana")
+))]
 #[link(name = "c")]
 extern "C" {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 #![feature(asm_experimental_arch)]
 #![feature(cfg_target_has_atomic)]
 #![feature(compiler_builtins)]
+#![cfg_attr(not(target_os = "solana"), feature(core_ffi_c))]
 #![feature(core_intrinsics)]
 #![feature(linkage)]
 #![feature(naked_functions)]
@@ -87,5 +88,13 @@ pub mod x86;
 
 #[cfg(target_arch = "x86_64")]
 pub mod x86_64;
+
+#[cfg(all(target_os = "solana", target_feature = "static-syscalls"))]
+#[cfg_attr(not(feature = "mangled-names"), no_mangle)]
+#[linkage = "weak"]
+pub unsafe extern "C" fn abort() -> ! {
+    let syscall: extern "C" fn() -> ! = core::mem::transmute(3069975057u64); // murmur32 hash of "abort"
+    syscall()
+}
 
 pub mod probestack;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 #![feature(linkage)]
 #![feature(naked_functions)]
 #![feature(repr_simd)]
+#![feature(isqrt)]
 #![cfg_attr(f16_enabled, feature(f16))]
 #![cfg_attr(f128_enabled, feature(f128))]
 #![no_builtins]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,12 +89,4 @@ pub mod x86;
 #[cfg(target_arch = "x86_64")]
 pub mod x86_64;
 
-#[cfg(all(target_os = "solana", target_feature = "static-syscalls"))]
-#[cfg_attr(not(feature = "mangled-names"), no_mangle)]
-#[linkage = "weak"]
-pub unsafe extern "C" fn abort() -> ! {
-    let syscall: extern "C" fn() -> ! = core::mem::transmute(3069975057u64); // murmur32 hash of "abort"
-    syscall()
-}
-
 pub mod probestack;

--- a/src/mem/mod.rs
+++ b/src/mem/mod.rs
@@ -8,17 +8,22 @@ type c_int = i16;
 #[cfg(not(target_pointer_width = "16"))]
 type c_int = i32;
 
+#[cfg(not(target_os = "solana"))]
 use core::intrinsics::{atomic_load_unordered, atomic_store_unordered, exact_div};
+#[cfg(not(target_os = "solana"))]
 use core::mem;
+#[cfg(not(target_os = "solana"))]
 use core::ops::{BitOr, Shl};
 
 // memcpy/memmove/memset have optimized implementations on some architectures
+#[cfg(not(target_os = "solana"))]
 #[cfg_attr(
     all(not(feature = "no-asm"), target_arch = "x86_64"),
     path = "x86_64.rs"
 )]
 mod impls;
 
+#[cfg(not(target_os = "solana"))]
 intrinsics! {
     #[mem_builtin]
     pub unsafe extern "C" fn memcpy(dest: *mut u8, src: *const u8, n: usize) -> *mut u8 {
@@ -62,6 +67,7 @@ intrinsics! {
 }
 
 // `bytes` must be a multiple of `mem::size_of::<T>()`
+#[cfg(not(target_os = "solana"))]
 #[cfg_attr(not(target_has_atomic_load_store = "8"), allow(dead_code))]
 fn memcpy_element_unordered_atomic<T: Copy>(dest: *mut T, src: *const T, bytes: usize) {
     unsafe {
@@ -75,6 +81,7 @@ fn memcpy_element_unordered_atomic<T: Copy>(dest: *mut T, src: *const T, bytes: 
 }
 
 // `bytes` must be a multiple of `mem::size_of::<T>()`
+#[cfg(not(target_os = "solana"))]
 #[cfg_attr(not(target_has_atomic_load_store = "8"), allow(dead_code))]
 fn memmove_element_unordered_atomic<T: Copy>(dest: *mut T, src: *const T, bytes: usize) {
     unsafe {
@@ -98,6 +105,7 @@ fn memmove_element_unordered_atomic<T: Copy>(dest: *mut T, src: *const T, bytes:
 }
 
 // `T` must be a primitive integer type, and `bytes` must be a multiple of `mem::size_of::<T>()`
+#[cfg(not(target_os = "solana"))]
 #[cfg_attr(not(target_has_atomic_load_store = "8"), allow(dead_code))]
 fn memset_element_unordered_atomic<T>(s: *mut T, c: u8, bytes: usize)
 where
@@ -124,6 +132,7 @@ where
     }
 }
 
+#[cfg(not(target_os = "solana"))]
 intrinsics! {
     #[cfg(target_has_atomic_load_store = "8")]
     pub unsafe extern "C" fn __llvm_memcpy_element_unordered_atomic_1(dest: *mut u8, src: *const u8, bytes: usize) -> () {
@@ -187,4 +196,205 @@ intrinsics! {
     pub unsafe extern "C" fn __llvm_memset_element_unordered_atomic_16(s: *mut u128, c: u8, bytes: usize) -> () {
         memset_element_unordered_atomic(s, c, bytes);
     }
+}
+
+// MEM functions have been rewritten to copy 8 byte chunks.  No
+// compensation for alignment is made here with the requirement that
+// the underlying hardware supports unaligned loads/stores.  If the
+// number of store operations is greater than 8 the memory operation
+// is performed in the run-time system instead, by calling the
+// corresponding "C" function.
+
+#[cfg(all(target_os = "solana", not(target_feature = "static-syscalls")))]
+mod syscalls {
+    extern "C" {
+        pub fn sol_memcpy_(dest: *mut u8, src: *const u8, n: u64);
+        pub fn sol_memmove_(dest: *mut u8, src: *const u8, n: u64);
+        pub fn sol_memset_(s: *mut u8, c: u8, n: u64);
+        pub fn sol_memcmp_(s1: *const u8, s2: *const u8, n: u64, result: *mut i32);
+    }
+}
+
+#[cfg(all(target_os = "solana", target_feature = "static-syscalls"))]
+mod syscalls {
+    pub(crate) fn sol_memcpy_(dest: *mut u8, src: *const u8, n: u64) {
+        let syscall: extern "C" fn(*mut u8, *const u8, u64) =
+            unsafe { core::mem::transmute(1904002211u64) }; // murmur32 hash of "sol_memcpy_"
+        syscall(dest, src, n)
+    }
+
+    pub(crate) fn sol_memmove_(dest: *mut u8, src: *const u8, n: u64) {
+        let syscall: extern "C" fn(*mut u8, *const u8, u64) =
+            unsafe { core::mem::transmute(1128493560u64) }; // murmur32 hash of "sol_memmove_"
+        syscall(dest, src, n)
+    }
+
+    pub(crate) fn sol_memcmp_(dest: *const u8, src: *const u8, n: u64, result: *mut i32) {
+        let syscall: extern "C" fn(*const u8, *const u8, u64, *mut i32) =
+            unsafe { core::mem::transmute(1608310321u64) }; // murmur32 hash of "sol_memcmp_"
+        syscall(dest, src, n, result)
+    }
+
+    pub(crate) fn sol_memset_(dest: *mut u8, c: u8, n: u64) {
+        let syscall: extern "C" fn(*mut u8, u8, u64) =
+            unsafe { core::mem::transmute(930151202u64) }; // murmur32 hash of "sol_memset_"
+        syscall(dest, c, n)
+    }
+}
+
+#[cfg(target_os = "solana")]
+use self::syscalls::*;
+
+#[cfg(target_os = "solana")]
+const NSTORE_THRESHOLD: usize = 15;
+
+#[cfg(target_os = "solana")]
+#[cfg_attr(
+    all(feature = "mem-unaligned", not(feature = "mangled-names")),
+    no_mangle
+)]
+#[inline]
+pub unsafe extern "C" fn memcpy(dest: *mut u8, src: *const u8, n: usize) -> *mut u8 {
+    let chunks = (n / 8) as isize;
+    let nstore = n - (7 * chunks) as usize;
+    if nstore > NSTORE_THRESHOLD {
+        sol_memcpy_(dest, src, n as u64);
+        return dest;
+    }
+    let mut i: isize = 0;
+    if chunks != 0 {
+        let dest_64 = dest as *mut _ as *mut u64;
+        let src_64 = src as *const _ as *const u64;
+        while i < chunks {
+            *dest_64.offset(i) = *src_64.offset(i);
+            i += 1;
+        }
+        i *= 8;
+    }
+    while i < n as isize {
+        *dest.offset(i) = *src.offset(i);
+        i += 1;
+    }
+    dest
+}
+
+#[cfg(target_os = "solana")]
+#[cfg_attr(
+    all(feature = "mem-unaligned", not(feature = "mangled-names")),
+    no_mangle
+)]
+#[inline]
+pub unsafe extern "C" fn memmove(dest: *mut u8, src: *const u8, n: usize) -> *mut u8 {
+    let chunks = (n / 8) as isize;
+    let nstore = n - (7 * chunks) as usize;
+    if nstore > NSTORE_THRESHOLD {
+        sol_memmove_(dest, src, n as u64);
+        return dest;
+    }
+    if src < dest as *const u8 {
+        // copy from end
+        let mut i = n as isize;
+        while i > chunks * 8 {
+            i -= 1;
+            *dest.offset(i) = *src.offset(i);
+        }
+        i = chunks;
+        if i > 0 {
+            let dest_64 = dest as *mut _ as *mut u64;
+            let src_64 = src as *const _ as *const u64;
+            while i > 0 {
+                i -= 1;
+                *dest_64.offset(i) = *src_64.offset(i);
+            }
+        }
+    } else {
+        // copy from beginning
+        let mut i: isize = 0;
+        if chunks != 0 {
+            let dest_64 = dest as *mut _ as *mut u64;
+            let src_64 = src as *const _ as *const u64;
+            while i < chunks {
+                *dest_64.offset(i) = *src_64.offset(i);
+                i += 1;
+            }
+            i *= 8;
+        }
+        while i < n as isize {
+            *dest.offset(i) = *src.offset(i);
+            i += 1;
+        }
+    }
+    dest
+}
+
+#[cfg(target_os = "solana")]
+#[cfg_attr(
+    all(feature = "mem-unaligned", not(feature = "mangled-names")),
+    no_mangle
+)]
+#[inline]
+pub unsafe extern "C" fn memset(s: *mut u8, c: c_int, n: usize) -> *mut u8 {
+    let chunks = (n / 8) as isize;
+    let nstore = n - (7 * chunks) as usize;
+    if nstore > NSTORE_THRESHOLD {
+        sol_memset_(s, c as u8, n as u64);
+        return s;
+    }
+    let mut i: isize = 0;
+    if chunks != 0 {
+        let mut c_64 = c as u64 & 0xFF as u64;
+        c_64 |= c_64 << 8;
+        c_64 |= c_64 << 16;
+        c_64 |= c_64 << 32;
+        let s_64 = s as *mut _ as *mut u64;
+        while i < chunks {
+            *s_64.offset(i) = c_64;
+            i += 1;
+        }
+        i *= 8;
+    }
+    while i < n as isize {
+        *s.offset(i) = c as u8;
+        i += 1;
+    }
+    s
+}
+
+#[cfg(target_os = "solana")]
+#[cfg_attr(
+    all(feature = "mem-unaligned", not(feature = "mangled-names")),
+    no_mangle
+)]
+#[inline]
+pub unsafe extern "C" fn memcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
+    let chunks = (n / 8) as isize;
+    let nstore = n - (7 * chunks) as usize;
+    if nstore > NSTORE_THRESHOLD {
+        let mut result = 0;
+        sol_memcmp_(s1, s2, n as u64, &mut result as *mut i32);
+        return result;
+    }
+    let mut i: isize = 0;
+    if chunks != 0 {
+        let s1_64 = s1 as *const _ as *const u64;
+        let s2_64 = s2 as *const _ as *const u64;
+        while i < chunks {
+            let a = *s1_64.offset(i);
+            let b = *s2_64.offset(i);
+            if a != b {
+                break;
+            }
+            i += 1;
+        }
+        i *= 8;
+    }
+    while i < n as isize {
+        let a = *s1.offset(i);
+        let b = *s2.offset(i);
+        if a != b {
+            return a as i32 - b as i32;
+        }
+        i += 1;
+    }
+    0
 }

--- a/src/mem/mod.rs
+++ b/src/mem/mod.rs
@@ -198,13 +198,6 @@ intrinsics! {
     }
 }
 
-// MEM functions have been rewritten to copy 8 byte chunks.  No
-// compensation for alignment is made here with the requirement that
-// the underlying hardware supports unaligned loads/stores.  If the
-// number of store operations is greater than 8 the memory operation
-// is performed in the run-time system instead, by calling the
-// corresponding "C" function.
-
 #[cfg(all(target_os = "solana", not(target_feature = "static-syscalls")))]
 mod syscalls {
     extern "C" {
@@ -246,35 +239,13 @@ mod syscalls {
 use self::syscalls::*;
 
 #[cfg(target_os = "solana")]
-const NSTORE_THRESHOLD: usize = 15;
-
-#[cfg(target_os = "solana")]
 #[cfg_attr(
     all(feature = "mem-unaligned", not(feature = "mangled-names")),
     no_mangle
 )]
 #[inline]
 pub unsafe extern "C" fn memcpy(dest: *mut u8, src: *const u8, n: usize) -> *mut u8 {
-    let chunks = (n / 8) as isize;
-    let nstore = n - (7 * chunks) as usize;
-    if nstore > NSTORE_THRESHOLD {
-        sol_memcpy_(dest, src, n as u64);
-        return dest;
-    }
-    let mut i: isize = 0;
-    if chunks != 0 {
-        let dest_64 = dest as *mut _ as *mut u64;
-        let src_64 = src as *const _ as *const u64;
-        while i < chunks {
-            *dest_64.offset(i) = *src_64.offset(i);
-            i += 1;
-        }
-        i *= 8;
-    }
-    while i < n as isize {
-        *dest.offset(i) = *src.offset(i);
-        i += 1;
-    }
+    sol_memcpy_(dest, src, n as u64);
     dest
 }
 
@@ -285,45 +256,7 @@ pub unsafe extern "C" fn memcpy(dest: *mut u8, src: *const u8, n: usize) -> *mut
 )]
 #[inline]
 pub unsafe extern "C" fn memmove(dest: *mut u8, src: *const u8, n: usize) -> *mut u8 {
-    let chunks = (n / 8) as isize;
-    let nstore = n - (7 * chunks) as usize;
-    if nstore > NSTORE_THRESHOLD {
-        sol_memmove_(dest, src, n as u64);
-        return dest;
-    }
-    if src < dest as *const u8 {
-        // copy from end
-        let mut i = n as isize;
-        while i > chunks * 8 {
-            i -= 1;
-            *dest.offset(i) = *src.offset(i);
-        }
-        i = chunks;
-        if i > 0 {
-            let dest_64 = dest as *mut _ as *mut u64;
-            let src_64 = src as *const _ as *const u64;
-            while i > 0 {
-                i -= 1;
-                *dest_64.offset(i) = *src_64.offset(i);
-            }
-        }
-    } else {
-        // copy from beginning
-        let mut i: isize = 0;
-        if chunks != 0 {
-            let dest_64 = dest as *mut _ as *mut u64;
-            let src_64 = src as *const _ as *const u64;
-            while i < chunks {
-                *dest_64.offset(i) = *src_64.offset(i);
-                i += 1;
-            }
-            i *= 8;
-        }
-        while i < n as isize {
-            *dest.offset(i) = *src.offset(i);
-            i += 1;
-        }
-    }
+    sol_memmove_(dest, src, n as u64);
     dest
 }
 
@@ -334,29 +267,7 @@ pub unsafe extern "C" fn memmove(dest: *mut u8, src: *const u8, n: usize) -> *mu
 )]
 #[inline]
 pub unsafe extern "C" fn memset(s: *mut u8, c: c_int, n: usize) -> *mut u8 {
-    let chunks = (n / 8) as isize;
-    let nstore = n - (7 * chunks) as usize;
-    if nstore > NSTORE_THRESHOLD {
-        sol_memset_(s, c as u8, n as u64);
-        return s;
-    }
-    let mut i: isize = 0;
-    if chunks != 0 {
-        let mut c_64 = c as u64 & 0xFF as u64;
-        c_64 |= c_64 << 8;
-        c_64 |= c_64 << 16;
-        c_64 |= c_64 << 32;
-        let s_64 = s as *mut _ as *mut u64;
-        while i < chunks {
-            *s_64.offset(i) = c_64;
-            i += 1;
-        }
-        i *= 8;
-    }
-    while i < n as isize {
-        *s.offset(i) = c as u8;
-        i += 1;
-    }
+    sol_memset_(s, c as u8, n as u64);
     s
 }
 
@@ -367,34 +278,7 @@ pub unsafe extern "C" fn memset(s: *mut u8, c: c_int, n: usize) -> *mut u8 {
 )]
 #[inline]
 pub unsafe extern "C" fn memcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
-    let chunks = (n / 8) as isize;
-    let nstore = n - (7 * chunks) as usize;
-    if nstore > NSTORE_THRESHOLD {
-        let mut result = 0;
-        sol_memcmp_(s1, s2, n as u64, &mut result as *mut i32);
-        return result;
-    }
-    let mut i: isize = 0;
-    if chunks != 0 {
-        let s1_64 = s1 as *const _ as *const u64;
-        let s2_64 = s2 as *const _ as *const u64;
-        while i < chunks {
-            let a = *s1_64.offset(i);
-            let b = *s2_64.offset(i);
-            if a != b {
-                break;
-            }
-            i += 1;
-        }
-        i *= 8;
-    }
-    while i < n as isize {
-        let a = *s1.offset(i);
-        let b = *s2.offset(i);
-        if a != b {
-            return a as i32 - b as i32;
-        }
-        i += 1;
-    }
-    0
+    let mut result = 0;
+    sol_memcmp_(s1, s2, n as u64, &mut result as *mut i32);
+    result
 }

--- a/testcrate/Cargo.toml
+++ b/testcrate/Cargo.toml
@@ -23,8 +23,11 @@ default-features = false
 features = ["public-test-deps"]
 
 [dev-dependencies]
-criterion = { version = "0.5.1", default-features = false, features = ["cargo_bench_support"] }
 paste = "1.0.15"
+
+[target.'cfg(not(target_arch = "sbf"))'.dev-dependencies]
+criterion = { version = "0.5.1", default-features = false, features = ["cargo_bench_support"] }
+
 
 [target.'cfg(all(target_arch = "arm", not(any(target_env = "gnu", target_env = "musl")), target_os = "linux"))'.dev-dependencies]
 test = { git = "https://github.com/japaric/utest" }
@@ -47,7 +50,7 @@ no-sys-f16-f128-convert = []
 no-sys-f16 = []
 
 # Enable report generation without bringing in more dependencies by default
-benchmarking-reports = ["criterion/plotters", "criterion/html_reports"]
+# benchmarking-reports = ["criterion/plotters", "criterion/html_reports"]
 
 [[bench]]
 name = "float_add"

--- a/testcrate/src/lib.rs
+++ b/testcrate/src/lib.rs
@@ -13,6 +13,7 @@
 //! Some floating point tests are disabled for specific architectures, because they do not have
 //! correct rounding.
 #![no_std]
+#![feature(isqrt)]
 #![cfg_attr(f128_enabled, feature(f128))]
 #![cfg_attr(f16_enabled, feature(f16))]
 

--- a/testcrate/tests/div_rem.rs
+++ b/testcrate/tests/div_rem.rs
@@ -139,7 +139,10 @@ macro_rules! float {
     };
 }
 
-#[cfg(not(all(target_arch = "x86", not(target_feature = "sse"))))]
+#[cfg(not(any(
+    all(target_arch = "x86", not(target_feature = "sse")),
+    target_family = "solana"
+)))]
 mod float_div {
     use super::*;
 

--- a/testcrate/tests/mem.rs
+++ b/testcrate/tests/mem.rs
@@ -37,6 +37,7 @@ fn memcpy_10() {
     }
 }
 
+#[cfg(not(target_os = "solana"))]
 #[test]
 fn memcpy_big() {
     // Make the arrays cross 3 pages
@@ -163,6 +164,7 @@ fn memmove_forward_misaligned_nonaligned_start() {
     }
 }
 
+#[cfg(not(target_os = "solana"))]
 #[test]
 fn memmove_forward_misaligned_aligned_start() {
     let mut arr = gen_arr::<32>();


### PR DESCRIPTION
Compiler-builtins 0.1.138 ships with Rust 1.84.1.