### PR TITLE
[SOL] Fix CI and compile previsouly incompatible functions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,6 +70,18 @@ jobs:
         - target: sbf-solana-solana
           os: ubuntu-latest
           rust: nightly-2024-11-01
+        - target: sbpf-solana-solana
+          os: ubuntu-latest
+          rust: nightly-2024-11-01
+        - target: sbpfv1-solana-solana
+          os: ubuntu-latest
+          rust: nightly-2024-11-01
+        - target: sbpfv2-solana-solana
+          os: ubuntu-latest
+          rust: nightly-2024-11-01
+        - target: sbpfv3-solana-solana
+          os: ubuntu-latest
+          rust: nightly-2024-11-01
         - target: thumbv6m-none-eabi
           os: ubuntu-latest
           rust: nightly-2024-11-01
@@ -115,7 +127,7 @@ jobs:
       run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
       shell: bash
     - run: rustup target add ${{ matrix.target }}
-      if: matrix.target != 'sbf-solana-solana'
+      if: ${{ !startsWith(matrix.target, 'sbf') && !startsWith(matrix.target, 'sbpf') }}
     - run: rustup component add llvm-tools-preview
     - uses: Swatinem/rust-cache@v2
       with:

--- a/build.rs
+++ b/build.rs
@@ -587,13 +587,6 @@ mod c {
 
         if target.os == "solana" {
             cfg.define("__ELF__", None);
-            // Remove the implementations that fail to build.
-            // This list should shrink to zero
-            sources.remove(&[
-                "__int_util", // Unsupported architecture error
-                "__mulvdi3",  // Unsupported signed division
-                "__mulvsi3",  // Unsupported signed division
-            ]);
         }
 
         // When compiling the C code we require the user to tell us where the

--- a/ci/docker/sbpf-solana-solana/Dockerfile
+++ b/ci/docker/sbpf-solana-solana/Dockerfile
@@ -19,7 +19,7 @@ RUN tar -xjf platform-tools-linux-x86_64.tar.bz2 --strip-components 1 -C /tmp/.c
 RUN rustup toolchain link solana /tmp/.cache/solana/v1.47/platform-tools/rust
 RUN cp -R ${HOME}/.rustup /tmp/
 
-ENV CARGO_TARGET_SBF_SOLANA_SOLANA_RUNNER="cargo-run-solana-tests --heap-size 104857600"
+ENV CARGO_TARGET_SBPF_SOLANA_SOLANA_RUNNER="cargo-run-solana-tests --heap-size 104857600"
 ENV LLVM_HOME="/tmp/.cache/solana/v1.47/platform-tools/llvm"
 ENV CC="/tmp/.cache/solana/v1.47/platform-tools/llvm/bin/clang"
 ENV RUSTUP_TOOLCHAIN="solana"

--- a/ci/docker/sbpfv1-solana-solana/Dockerfile
+++ b/ci/docker/sbpfv1-solana-solana/Dockerfile
@@ -19,7 +19,7 @@ RUN tar -xjf platform-tools-linux-x86_64.tar.bz2 --strip-components 1 -C /tmp/.c
 RUN rustup toolchain link solana /tmp/.cache/solana/v1.47/platform-tools/rust
 RUN cp -R ${HOME}/.rustup /tmp/
 
-ENV CARGO_TARGET_SBF_SOLANA_SOLANA_RUNNER="cargo-run-solana-tests --heap-size 104857600"
+ENV CARGO_TARGET_SBPFV1_SOLANA_SOLANA_RUNNER="cargo-run-solana-tests --heap-size 104857600"
 ENV LLVM_HOME="/tmp/.cache/solana/v1.47/platform-tools/llvm"
 ENV CC="/tmp/.cache/solana/v1.47/platform-tools/llvm/bin/clang"
 ENV RUSTUP_TOOLCHAIN="solana"

--- a/ci/docker/sbpfv2-solana-solana/Dockerfile
+++ b/ci/docker/sbpfv2-solana-solana/Dockerfile
@@ -19,7 +19,7 @@ RUN tar -xjf platform-tools-linux-x86_64.tar.bz2 --strip-components 1 -C /tmp/.c
 RUN rustup toolchain link solana /tmp/.cache/solana/v1.47/platform-tools/rust
 RUN cp -R ${HOME}/.rustup /tmp/
 
-ENV CARGO_TARGET_SBF_SOLANA_SOLANA_RUNNER="cargo-run-solana-tests --heap-size 104857600"
+ENV CARGO_TARGET_SBPFV2_SOLANA_SOLANA_RUNNER="cargo-run-solana-tests --heap-size 104857600"
 ENV LLVM_HOME="/tmp/.cache/solana/v1.47/platform-tools/llvm"
 ENV CC="/tmp/.cache/solana/v1.47/platform-tools/llvm/bin/clang"
 ENV RUSTUP_TOOLCHAIN="solana"

--- a/ci/docker/sbpfv3-solana-solana/Dockerfile
+++ b/ci/docker/sbpfv3-solana-solana/Dockerfile
@@ -19,7 +19,7 @@ RUN tar -xjf platform-tools-linux-x86_64.tar.bz2 --strip-components 1 -C /tmp/.c
 RUN rustup toolchain link solana /tmp/.cache/solana/v1.47/platform-tools/rust
 RUN cp -R ${HOME}/.rustup /tmp/
 
-ENV CARGO_TARGET_SBF_SOLANA_SOLANA_RUNNER="cargo-run-solana-tests --heap-size 104857600"
+ENV CARGO_TARGET_SBPFV3_SOLANA_SOLANA_RUNNER="cargo-run-solana-tests --heap-size 104857600"
 ENV LLVM_HOME="/tmp/.cache/solana/v1.47/platform-tools/llvm"
 ENV CC="/tmp/.cache/solana/v1.47/platform-tools/llvm/bin/clang"
 ENV RUSTUP_TOOLCHAIN="solana"

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -24,16 +24,26 @@ if [ "${NO_STD:-}" = "1" ]; then
     echo "nothing to do for no_std"
 else
     run="cargo test --manifest-path testcrate/Cargo.toml --no-fail-fast --target $target"
-    $run
+
+    if [[ ! "$target" =~ ^sbf && ! "$target" =~ ^sbpf- && ! "$target" =~ ^sbpfv3- ]]; then
+      # Not using release mode causes a stack overflow in SBPFv0
+      # There is a bug in SBPFv3 whereby we were not adding returns to -O0 code
+      $run
+      $run --features c
+      $run --features no-asm
+      $run --features no-f16-f128
+    fi
+
     $run --release
-    $run --features c
     $run --features c --release
-    $run --features no-asm
     $run --features no-asm --release
-    $run --features no-f16-f128
     $run --features no-f16-f128 --release
-    $run --benches
-    $run --benches --release
+
+    if [[ ! "$target" =~ ^sbf && ! "$target" =~ ^sbpf ]]; then
+      # Benches require criterion, which is not compatible with SBPF
+      $run --benches
+      $run --benches --release
+    fi
 fi
 
 if [ "${TEST_VERBATIM:-}" = "1" ]; then

--- a/testcrate/tests/conv.rs
+++ b/testcrate/tests/conv.rs
@@ -84,7 +84,9 @@ mod i_to_f {
                         if !Float::eq_repr(f0, f1) && !cfg!(any(
                             target_arch = "x86",
                             target_arch = "powerpc",
-                            target_arch = "powerpc64"
+                            target_arch = "powerpc64",
+                            // In SBF, the rounding bug exists when ALU32 is disbaled.
+                            not(target_feature = "static-syscalls"),
                         )) {
                             panic!(
                                 "{}({}): std: {:?}, builtins: {:?}",


### PR DESCRIPTION
Since we are doing a new platform tools release to fix the issue with drift sort, I decided to fix the CI in compiler-builtins.